### PR TITLE
Fix build when the package is used without default features

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,6 +35,8 @@ jobs:
         run: cargo build --release
       - name: Run tests
         run: cargo test
+      - name: Run tests without default features.
+        run: cargo test --no-default-features
       - name: Run examples with deserialize_duration
         run: cargo run --example deserialize_duration
       - name: Run examples with deserialize_duration_chrono

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,28 @@ categories = ["parsing", "date-and-time"]
 repository = "https://github.com/baoyachi/duration-str"
 license = "MIT AND Apache-2.0"
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["chrono", "serde"]
 
 [dependencies]
 nom = "6.1.2"
 anyhow = "1.0.38"
 chrono = { version = "0.4.19", optional = true }
 serde = { version = "1.0.124", features = ["derive"], optional = true }
-serde_json = { version = "1.0.64", optional = true }
 rust_decimal = { version = "1.15", default-features = false }
 
-[features]
-default = ["chrono", "serde", "serde_json"]
+[dev-dependencies]
+serde_json = { version = "1.0.64" }
+
+# docs.rs-specific configuration
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+
+[[example]]
+name = "deserialize_duration"
+required-features = ["serde"]
+
+[[example]]
+name = "deserialize_duration_chrono"
+required-features = ["chrono", "serde"]


### PR DESCRIPTION
* Add `cargo test --no-default-features` to the regularly run checks.
* Move `serde_json` to dev-deps.
* Make the doctests conditional, so that tests pass without default features.
* Add metadata to instruct docs.rs to enable all features, in addition to `default` enabling `chrono` and `serde`.