### PR TITLE
Make the plus operator optional

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,6 +35,8 @@ jobs:
         run: cargo build --release
       - name: Run tests
         run: cargo test
+      - name: Run tests without default features.
+        run: cargo test --no-default-features
       - name: Run examples with deserialize_duration
         run: cargo run --example deserialize_duration
       - name: Run examples with deserialize_duration_chrono

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,28 @@ categories = ["parsing", "date-and-time"]
 repository = "https://github.com/baoyachi/duration-str"
 license = "MIT AND Apache-2.0"
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["chrono", "serde"]
 
 [dependencies]
 nom = "6.1.2"
 anyhow = "1.0.38"
 chrono = { version = "0.4.19", optional = true }
 serde = { version = "1.0.124", features = ["derive"], optional = true }
-serde_json = { version = "1.0.64", optional = true }
 rust_decimal = { version = "1.15", default-features = false }
 
-[features]
-default = ["chrono", "serde", "serde_json"]
+[dev-dependencies]
+serde_json = { version = "1.0.64" }
+
+# docs.rs-specific configuration
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+
+[[example]]
+name = "deserialize_duration"
+required-features = ["serde"]
+
+[[example]]
+name = "deserialize_duration_chrono"
+required-features = ["chrono", "serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! - ms:Millisecond.Support string value: ["ms" | "MS" | "Millisecond" | "MilliSecond" | "MILLISECOND" | "millisecond" | "mSEC" ]. e.g. 1ms
 //!
-//! - µs:Microsecond.Support string value: ["µs" | "µS" | "µsecond" | "Microsecond" | "MicroSecond" | "MICROSECOND" | "microsecond" | "µSEC"]. e.g. 1µs
+//! - µs:Microsecond.Support string value: ["µs" | "µS" | "µsecond" | "us" | "uS" | "usecond" | "Microsecond" | "MicroSecond" | "MICROSECOND" | "microsecond" | "µSEC"]. e.g. 1µs
 //!
 //! - ns:Nanosecond.Support string value: ["ns" | "NS" | "Nanosecond" | "NanoSecond" | "NANOSECOND" | "nanosecond" | "nSEC"]. e.g. 1ns
 //!
@@ -286,10 +286,12 @@ fn time_unit(input: &str) -> IResult<&str, TimeUnit> {
         "m" | "min" | "minute" => Ok((input, TimeUnit::Minute)),
         "s" | "sec" | "second" => Ok((input, TimeUnit::Second)),
         "ms" | "msec" | "millisecond" => Ok((input, TimeUnit::MilliSecond)),
-        "µs" | "µsec" | "µsecond" | "microsecond" => Ok((input, TimeUnit::MicroSecond)),
+        "µs" | "µsec" | "µsecond" | "us" | "usec" | "usecond" | "microsecond" => {
+            Ok((input, TimeUnit::MicroSecond))
+        }
         "ns" | "nsec" | "nanosecond" => Ok((input, TimeUnit::NanoSecond)),
         _ => Err(nom::Err::Error(nom::error::Error::new(
-            "expect one of [y,mon,w,d,h,m,s,ms,µs,ns]",
+            "expect one of [y,mon,w,d,h,m,s,ms,µs,us,ns] or their longer forms",
             ErrorKind::Alpha,
         ))),
     }


### PR DESCRIPTION
... and support `us` for microseconds in addition to `µs`

Builds on #4 