### PR TITLE
Fix lints with restricted feature set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@
 //! ```
 
 use anyhow::anyhow;
-#[cfg(feature = "chrono")]
+#[cfg(all(feature = "chrono", feature = "serde"))]
 use chrono::Duration as CDuration;
 
 use nom::{
@@ -179,7 +179,7 @@ use nom::{
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use std::time::Duration;
-#[cfg(feature = "time")]
+#[cfg(all(feature = "time", feature = "serde"))]
 use time::Duration as TDuration;
 
 #[cfg(feature = "chrono")]


### PR DESCRIPTION
$ cargo build --no-default-features --features time warning: unused import: `time::Duration as TDuration`
   --> src/lib.rs:183:5
    |
183 | use time::Duration as TDuration;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: `duration-str` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s

$ cargo build --no-default-features --features chrono warning: unused import: `chrono::Duration as CDuration`
   --> src/lib.rs:170:5
    |
170 | use chrono::Duration as CDuration;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: `duration-str` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 2.27s