### PR TITLE
feat: optional spaces between digits and unit

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-tarpaulin
-          version: 0.14.2
+          version: 0.31.5
           use-tool-cache: true
       - name: Checkout
         uses: actions/checkout@v4

--- a/benches/parser_benchmark.rs
+++ b/benches/parser_benchmark.rs
@@ -27,11 +27,11 @@ fn impeccable_duration() {
 }
 
 pub fn duration_str_benchmark(c: &mut Criterion) {
-    c.bench_function("duration_str", |b| b.iter(|| parse_duration()));
+    c.bench_function("duration_str", |b| b.iter(parse_duration));
 }
 
 pub fn impeccable_benchmark(c: &mut Criterion) {
-    c.bench_function("impeccable", |b| b.iter(|| impeccable_duration()));
+    c.bench_function("impeccable", |b| b.iter(impeccable_duration));
 }
 
 criterion_group!(benches, duration_str_benchmark, impeccable_benchmark);

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -164,6 +164,22 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_deserialize_unit_with_spaces() {
+        #[derive(Debug, Deserialize)]
+        struct Config {
+            #[serde(deserialize_with = "deserialize_duration_time")]
+            time_ticker: TDuration,
+        }
+        let json = r#"{"time_ticker":"1 y + 30"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.time_ticker,
+            TDuration::nanoseconds(ONE_YEAR_NANOSECOND as i64) + TDuration::seconds(30)
+        );
+    }
+
     #[cfg(all(feature = "serde", feature = "chrono"))]
     #[test]
     fn test_deserialize_duration_chrono() {


### PR DESCRIPTION
This updates the parser to allow optional spaces between digits and unit, so that "1 month", "1 month 2 days", and similar constructs will parse successfully.